### PR TITLE
fix halo2_proofs_axiom dependency error in account-age

### DIFF
--- a/account-age/Cargo.toml
+++ b/account-age/Cargo.toml
@@ -17,7 +17,7 @@ ark-std = { version = "0.3.0", features = ["print-trace"], optional = true }
 axiom-eth = { git = "https://github.com/axiom-crypto/axiom-eth.git", tag = "v2023_01_30", features = ["halo2-axiom", "aggregation", "evm", "providers"], default-features = false }
 
 # halo2
-halo2_proofs_axiom = { git = "https://github.com/axiom-crypto/halo2.git", branch = "axiom/faster-witness-generation", package = "halo2_proofs"}
+halo2_proofs = { git = "https://github.com/axiom-crypto/halo2.git", tag = "v2023_01_17", package = "halo2_proofs" }
 halo2-base = { git = "https://github.com/axiom-crypto/halo2-lib.git", tag = "v0.2.2", features = ["halo2-axiom"], default-features = false }
 
 # crypto


### PR DESCRIPTION
I got this error when I ran `cargo build` , so fixed its dependency.

![Screen Shot 2023-02-27 at 14 30 06](https://user-images.githubusercontent.com/1056248/221482076-7847a16b-e71c-4894-ab89-33da314f4bad.png)

The issue is that axiom/faster-witness-generation branch does not exist on the axiom-crypto/halo2 repository.
